### PR TITLE
Quantum Bot improvements

### DIFF
--- a/.theia/launch.json
+++ b/.theia/launch.json
@@ -1,0 +1,20 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Debug Random Bot",
+      "program": "${workspaceFolder}/play-bot.js"
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Debug Quantum Bot",
+      "program": "${workspaceFolder}/play-bot.js",
+      "args": [ "--bot=quantum" ]
+    }
+  ]
+}

--- a/bots/quantum.js
+++ b/bots/quantum.js
@@ -57,6 +57,7 @@ function evaluateCard (card, game) {
         // Bonus
         {
           'cards': 2,
+          'city': 9, // Source: "4.5 Points from City"
           'heat': 1,
           'megacredits': 1,
           'oceans': 14,

--- a/bots/quantum.js
+++ b/bots/quantum.js
@@ -131,6 +131,7 @@ function evaluateCard (card, game) {
 
 // Source: https://boardgamegeek.com/thread/1847708/quantified-guide-tm-strategy
 function evaluateOption (option, game) {
+  let match = null;
   if (option.playerInputType === 'OR_OPTIONS') {
     // Return the value of the best sub-option
     return sortByEstimatedValue(option.options, evaluateOption, game)[0].value
@@ -148,7 +149,7 @@ function evaluateOption (option, game) {
     // We definitely want to do that
     return 100;
   }
-  if (option.title.match(/Convert \d+ plants into greenery/)) {
+  if (match = option.title.match(/Convert (\d+) plants into greenery/)) {
     // Source: "2.1 Card Advantage"
     return 19;
   }
@@ -156,25 +157,30 @@ function evaluateOption (option, game) {
     // Source: "1.1 Standard Cards"
     return 10;
   }
-  if (option.title === 'Power plant (11 MC)') {
-    // Source: "2.1 Card Advantage"
-    return -4;
+  if (match = option.title.match(/Power plant \((\d+) MC\)/)) {
+    const cost = parseInt(match[1], 10)
+    // Source: "1.1 Standard Cards"
+    return 7 - cost;
   }
-  if (option.title === 'Asteroid (14 MC)') {
-    // Source: "2.1 Card Advantage"
-    return -4;
+  if (match = option.title.match(/Asteroid \((\d+) MC\)/)) {
+    const cost = parseInt(match[1], 10);
+    // Source: "1.1 Standard Cards"
+    return 10 - cost;
   }
-  if (option.title === 'Aquifer (18 MC)') {
-    // Source: "2.1 Card Advantage"
-    return -4;
+  if (match = option.title.match(/Aquifer \((\d+) MC\)/)) {
+    const cost = parseInt(match[1], 10);
+    // Source: "1.1 Standard Cards"
+    return 14 - cost;
   }
-  if (option.title === 'Greenery (23 MC)') {
+  if (match = option.title.match(/Greenery \((\d+) MC\)/)) {
+    const cost = parseInt(match[1], 10);
     // Source: "2.1 Card Advantage"
-    return -4;
+    return 19 - cost;
   }
-  if (option.title === 'City (25 MC)') {
-    // Source: "2.1 Card Advantage"
-    return -4;
+  if (match = option.title.match(/City \((\d+) MC\)/)) {
+    const cost = parseInt(match[1], 10);
+    // Source: "4.5 Points from City"
+    return 9 - cost;
   }
   if (option.title === 'Pass for this generation') {
     // Only pass when no "good" choices remain

--- a/bots/quantum.js
+++ b/bots/quantum.js
@@ -139,6 +139,11 @@ function evaluateOption (option, game) {
     // Return the value of the best playable card
     return sortByEstimatedValue(option.cards, evaluateCard, game)[0].value;
   }
+  if (option.playerInputType === 'SELECT_SPACE') {
+    // Return the value of the best available space
+    const spaces = option.availableSpaces.map(id => game.spaces.find(s => s.id === id));
+    return sortByEstimatedValue(spaces, evaluateSpace, game)[0].value;
+  }
   if (option.title.message && option.title.message.match(/Take first action of.*/)) {
     // We definitely want to do that
     return 100;

--- a/play-bot.js
+++ b/play-bot.js
@@ -129,8 +129,8 @@ function annotateWaitingFor (game, waitingFor) {
 // Add additional useful information to cards
 function annotateCards (game, cards) {
   for (const card of cards) {
-    // For some reason, card.calculatedCost is always 0.
-    // But we get this info from the dealt project cards or cards in hand.
+    // BUG: For some reason, card.calculatedCost is always 0.
+    // But we can get this info from the dealt project cards or cards in hand.
     const cardInHand = game.cardsInHand.find(c => c.name === card.name);
     if (card.calculatedCost === 0 && cardInHand && cardInHand.calculatedCost) {
       card.calculatedCost = cardInHand.calculatedCost;
@@ -146,6 +146,11 @@ function annotateCards (game, cards) {
       continue;
     }
     card.cardType = projectCard.cardType;
+    // If we still don't know the card's cost, get it from the reference card.
+    /* FIXME: Why does this reduce the average score of Quantum Bot by 7 points?
+    if (card.calculatedCost === 0) {
+      card.calculatedCost = projectCard.cost;
+    } */
     if (!('tags' in card)) {
       card.tags = projectCard.tags;
     }


### PR DESCRIPTION
Unfortunately, this seems to regress the average score:

- Current state on `master` (https://github.com/jankeromnes/terraforming-mars-bot/commit/31ad841f6b37bcaefa2d376164e24ddaeb6922c3):

```
Played 100 games. Score summary:
  - quantum: average 52.03 points (min 32, max 85)
```

- This Pull Request (https://github.com/jankeromnes/terraforming-mars-bot/commit/e0b7933befa13a9e62576b8af63c917956c83dee):

```
Played 100 games. Score summary:
  - quantum: average 45.32 points (min 26, max 69)
```

I'm not exactly sure why, but it would be a shame to make Quantum Bot play _less_ good than how it plays now. 😕